### PR TITLE
Added several abbreviations for brackets

### DIFF
--- a/plugin/unicoder.vim
+++ b/plugin/unicoder.vim
@@ -240,6 +240,24 @@ function! s:setup_abbreviations()
   Prefixab  \\ nexists     ∄
   Prefixab  \\ nex         ∄
 
+  " Brackets {{{
+  Prefixab  \\ lceil        ⌈
+  Prefixab  \\ rceil        ⌉
+
+  Prefixab  \\ lfloor       ⌊
+  Prefixab  \\ rfloor       ⌋
+
+  Prefixab  \\ langle       ⟨
+  Prefixab  \\ rangle       ⟩
+
+  Prefixab  \\ llens        ⦇
+  Prefixab  \\ rlens        ⦈
+
+  Noprefixab \[[            ⟦
+  Noprefixab \]]            ⟧
+  " }}}
+
+
   " Sets {{{
   Prefixab  \\ empty       ∅
   Prefixab  \\ emptyset    ∅


### PR DESCRIPTION
I started using your plugin and I find it very useful. While using it,I needed to define some abbreviations for several brackets and I thought others might find them useful (and, also, I would get them for free when I install the plugin on another machine :-) )